### PR TITLE
GUNDI-5535: Split permanent 4xx errors from retryable errors, surface buffer misses

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -14,5 +14,12 @@ class DispatcherException(Exception):
     pass
 
 
+class NonRetryableDispatchError(DispatcherException):
+    """Delivery cannot succeed by retrying (e.g. permanent 4xx from the destination).
+    The message must be sent to the dead-letter topic and acked."""
+
+    pass
+
+
 class TooManyRequests(Exception):
     pass

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -117,6 +117,20 @@ def is_permanent_client_error(exception: Exception) -> bool:
     return 400 <= status_code < 500 and status_code not in (408, 429)
 
 
+def has_valid_location(
+    related_event: gundi_schemas_v2.TrapTaggerImageMetadata,
+) -> bool:
+    # TrapTagger resolves the site from the coordinates. A 0,0 location means
+    # the camera has no location configured at the source, and TrapTagger
+    # rejects it with "400 Missing site information"
+    try:
+        latitude = float(related_event.latitude)
+        longitude = float(related_event.longitude)
+    except (TypeError, ValueError):
+        return False
+    return latitude != 0.0 or longitude != 0.0
+
+
 async def dispatch_image(
     integration: gundi_schemas_v2.Integration,
     image: gundi_schemas_v2.TrapTaggerImage,
@@ -354,6 +368,30 @@ async def handle_traptagger_attachment(
                 topic_name=settings.DISPATCHER_EVENTS_TOPIC,
             )
             raise NonRetryableDispatchError(error_msg) from e
+        if related_event and not has_valid_location(related_event):
+            # TrapTagger will reject the image, so warn the user instead of posting it
+            warning_msg = (
+                f"Image {gundi_id} was not sent to TrapTagger because camera '{related_event.camera}' "
+                f"has no location set (latitude/longitude are {related_event.latitude},{related_event.longitude}). "
+                "TrapTagger requires a site identifier or location to accept images. "
+                "Please set the camera location in the data provider."
+            )
+            logger.warning(warning_msg)
+            current_span.set_attribute("error", warning_msg)
+            await publish_event(
+                event=system_events.DispatcherCustomLog(
+                    payload=gundi_schemas_v2.CustomDispatcherLog(
+                        gundi_id=gundi_id,
+                        related_to=related_to,
+                        data_provider_id=data_provider_id,
+                        destination_id=destination_id,
+                        title=warning_msg,
+                        level=gundi_schemas_v2.LogLevel.WARNING,
+                    )
+                ),
+                topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+            )
+            raise NonRetryableDispatchError(warning_msg)
         # Send image plus metadata to WPS Watch
         return await dispatch_image(
             integration=destination_integration,

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -148,6 +148,33 @@ async def dispatch_image(
                 "traptagger_dispatcher.error_dispatching_observation",
                 kind=SpanKind.CLIENT,
             ) as error_span:
+                if is_missing_site_error(e):
+                    # Rejected because the camera has no site or location configured.
+                    # Warn the user with an actionable message instead of a delivery error.
+                    camera = getattr(related_event, "camera", "unknown")
+                    latitude = getattr(related_event, "latitude", "?")
+                    longitude = getattr(related_event, "longitude", "?")
+                    warning_msg = (
+                        f"TrapTagger rejected image {gundi_id}: camera '{camera}' needs a site identifier "
+                        f"or a valid location (current latitude/longitude: {latitude},{longitude}). "
+                        "Please set the camera location in the data provider."
+                    )
+                    logger.warning(warning_msg)
+                    error_span.set_attribute("error", warning_msg)
+                    await publish_event(
+                        event=system_events.DispatcherCustomLog(
+                            payload=gundi_schemas_v2.CustomDispatcherLog(
+                                gundi_id=gundi_id,
+                                related_to=related_to,
+                                data_provider_id=data_provider_id,
+                                destination_id=destination_id,
+                                title=warning_msg,
+                                level=gundi_schemas_v2.LogLevel.WARNING,
+                            )
+                        ),
+                        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+                    )
+                    raise NonRetryableDispatchError(warning_msg) from e
                 error_msg = f"Error dispatching observation {gundi_id} to destination {destination_id}: {type(e).__name__}: {e}"
                 logger.exception(error_msg)
                 error_span.set_attribute("error", error_msg)
@@ -165,32 +192,6 @@ async def dispatch_image(
                     logger.debug(
                         f"Server response: status: {server_response_status}, body: {server_response_body}"
                     )
-                if is_missing_site_error(e):
-                    # Rejected because the camera has no site or location configured.
-                    # Warn the user with an actionable message instead of a delivery error.
-                    camera = getattr(related_event, "camera", "unknown")
-                    latitude = getattr(related_event, "latitude", "?")
-                    longitude = getattr(related_event, "longitude", "?")
-                    warning_msg = (
-                        f"TrapTagger rejected image {gundi_id}: camera '{camera}' needs a site identifier "
-                        f"or a valid location (current latitude/longitude: {latitude},{longitude}). "
-                        "Please set the camera location in the data provider."
-                    )
-                    logger.warning(warning_msg)
-                    await publish_event(
-                        event=system_events.DispatcherCustomLog(
-                            payload=gundi_schemas_v2.CustomDispatcherLog(
-                                gundi_id=gundi_id,
-                                related_to=related_to,
-                                data_provider_id=data_provider_id,
-                                destination_id=destination_id,
-                                title=warning_msg,
-                                level=gundi_schemas_v2.LogLevel.WARNING,
-                            )
-                        ),
-                        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
-                    )
-                    raise NonRetryableDispatchError(warning_msg) from e
                 # Emit events for the portal and other interested services (EDA)
                 await publish_event(
                     event=system_events.ObservationDeliveryFailed(

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -117,18 +117,14 @@ def is_permanent_client_error(exception: Exception) -> bool:
     return 400 <= status_code < 500 and status_code not in (408, 429)
 
 
-def has_valid_location(
-    related_event: gundi_schemas_v2.TrapTaggerImageMetadata,
-) -> bool:
-    # TrapTagger resolves the site from the coordinates. A 0,0 location means
-    # the camera has no location configured at the source, and TrapTagger
-    # rejects it with "400 Missing site information"
-    try:
-        latitude = float(related_event.latitude)
-        longitude = float(related_event.longitude)
-    except (TypeError, ValueError):
+def is_missing_site_error(exception: Exception) -> bool:
+    # TrapTagger resolves the site from the coordinates. A camera with no
+    # location configured at the source (0,0) is rejected with this error
+    if not isinstance(exception, httpx.HTTPStatusError):
         return False
-    return latitude != 0.0 or longitude != 0.0
+    if exception.response.status_code != 400:
+        return False
+    return "missing site information" in exception.response.text.lower()
 
 
 async def dispatch_image(
@@ -169,6 +165,32 @@ async def dispatch_image(
                     logger.debug(
                         f"Server response: status: {server_response_status}, body: {server_response_body}"
                     )
+                if is_missing_site_error(e):
+                    # Rejected because the camera has no site or location configured.
+                    # Warn the user with an actionable message instead of a delivery error.
+                    camera = getattr(related_event, "camera", "unknown")
+                    latitude = getattr(related_event, "latitude", "?")
+                    longitude = getattr(related_event, "longitude", "?")
+                    warning_msg = (
+                        f"TrapTagger rejected image {gundi_id}: camera '{camera}' needs a site identifier "
+                        f"or a valid location (current latitude/longitude: {latitude},{longitude}). "
+                        "Please set the camera location in the data provider."
+                    )
+                    logger.warning(warning_msg)
+                    await publish_event(
+                        event=system_events.DispatcherCustomLog(
+                            payload=gundi_schemas_v2.CustomDispatcherLog(
+                                gundi_id=gundi_id,
+                                related_to=related_to,
+                                data_provider_id=data_provider_id,
+                                destination_id=destination_id,
+                                title=warning_msg,
+                                level=gundi_schemas_v2.LogLevel.WARNING,
+                            )
+                        ),
+                        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+                    )
+                    raise NonRetryableDispatchError(warning_msg) from e
                 # Emit events for the portal and other interested services (EDA)
                 await publish_event(
                     event=system_events.ObservationDeliveryFailed(
@@ -368,30 +390,6 @@ async def handle_traptagger_attachment(
                 topic_name=settings.DISPATCHER_EVENTS_TOPIC,
             )
             raise NonRetryableDispatchError(error_msg) from e
-        if related_event and not has_valid_location(related_event):
-            # TrapTagger will reject the image, so warn the user instead of posting it
-            warning_msg = (
-                f"Image {gundi_id} was not sent to TrapTagger because camera '{related_event.camera}' "
-                f"has no location set (latitude/longitude are {related_event.latitude},{related_event.longitude}). "
-                "TrapTagger requires a site identifier or location to accept images. "
-                "Please set the camera location in the data provider."
-            )
-            logger.warning(warning_msg)
-            current_span.set_attribute("error", warning_msg)
-            await publish_event(
-                event=system_events.DispatcherCustomLog(
-                    payload=gundi_schemas_v2.CustomDispatcherLog(
-                        gundi_id=gundi_id,
-                        related_to=related_to,
-                        data_provider_id=data_provider_id,
-                        destination_id=destination_id,
-                        title=warning_msg,
-                        level=gundi_schemas_v2.LogLevel.WARNING,
-                    )
-                ),
-                topic_name=settings.DISPATCHER_EVENTS_TOPIC,
-            )
-            raise NonRetryableDispatchError(warning_msg)
         # Send image plus metadata to WPS Watch
         return await dispatch_image(
             integration=destination_integration,

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -110,11 +110,12 @@ async def get_related_event(event_id, destination_id):
 
 
 def is_permanent_client_error(exception: Exception) -> bool:
+    # 401/403 (auth) are retried because a rotated/expired API key is usually fixed;
     # 408 (timeout) and 429 (rate limit) are transient; other 4xx cannot succeed by retrying
     if not isinstance(exception, httpx.HTTPStatusError):
         return False
     status_code = exception.response.status_code
-    return 400 <= status_code < 500 and status_code not in (408, 429)
+    return 400 <= status_code < 500 and status_code not in (401, 403, 408, 429)
 
 
 def is_missing_site_error(exception: Exception) -> bool:

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -174,6 +174,27 @@ async def dispatch_image(
                         ),
                         topic_name=settings.DISPATCHER_EVENTS_TOPIC,
                     )
+                    # Also record a delivery failure so the observation doesn't
+                    # look perpetually in-flight in the portal delivery status
+                    await publish_event(
+                        event=system_events.ObservationDeliveryFailed(
+                            payload=system_events.DeliveryErrorDetails(
+                                error=warning_msg,
+                                error_traceback=traceback.format_exc(),
+                                server_response_status=e.response.status_code,
+                                server_response_body=e.response.text,
+                                observation=gundi_schemas_v2.DispatchedObservation(
+                                    gundi_id=gundi_id,
+                                    related_to=related_to,
+                                    external_id=None,
+                                    data_provider_id=data_provider_id,
+                                    destination_id=destination_id,
+                                    delivered_at=datetime.now(timezone.utc),  # UTC
+                                ),
+                            )
+                        ),
+                        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+                    )
                     raise NonRetryableDispatchError(warning_msg) from e
                 error_msg = f"Error dispatching observation {gundi_id} to destination {destination_id}: {type(e).__name__}: {e}"
                 logger.exception(error_msg)

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -9,7 +9,7 @@ from gundi_core.events.transformers import (
     AttachmentTransformedTrapTagger,
 )
 from app.core import tracing, settings
-from app.core.errors import ReferenceDataError
+from app.core.errors import NonRetryableDispatchError, ReferenceDataError
 from app.core.utils import (
     is_null,
     get_redis_db,
@@ -103,12 +103,18 @@ async def get_related_event(event_id, destination_id):
         gundi_id=event_id, destination_id=destination_id
     )
     if not related_observation:
-        error_msg = (
-            f"Error getting related observation {event_id}. Will retry later.",
-        )
+        error_msg = f"Error getting related observation {event_id}. Will retry later."
         logger.error(error_msg)
         raise ReferenceDataError(error_msg)
     return related_observation
+
+
+def is_permanent_client_error(exception: Exception) -> bool:
+    # 408 (timeout) and 429 (rate limit) are transient; other 4xx cannot succeed by retrying
+    if not isinstance(exception, httpx.HTTPStatusError):
+        return False
+    status_code = exception.response.status_code
+    return 400 <= status_code < 500 and status_code not in (408, 429)
 
 
 async def dispatch_image(
@@ -136,6 +142,8 @@ async def dispatch_image(
                 logger.exception(error_msg)
                 error_span.set_attribute("error", error_msg)
                 # Extract additional response details if available
+                server_response_status = None
+                server_response_body = None
                 if (
                     response := getattr(e, "response", None)
                 ) is not None:  # bool(response) on status errors returns False
@@ -167,6 +175,9 @@ async def dispatch_image(
                     ),
                     topic_name=settings.DISPATCHER_EVENTS_TOPIC,
                 )
+                if is_permanent_client_error(e):
+                    # Retrying cannot succeed. Send to DLQ and ack instead.
+                    raise NonRetryableDispatchError(error_msg) from e
                 # Raise so it can be retried by GCP
                 raise e
         else:
@@ -218,6 +229,8 @@ async def handle_traptagger_event(event: EventTransformedTrapTagger, attributes:
             error_msg = f"Error caching image metadata for {gundi_id} and {destination_id}: {type(e).__name__}: {e}"
             logger.exception(error_msg)
             # Extract additional response details if available
+            server_response_status = None
+            server_response_body = None
             if (
                 response := getattr(e, "response", None)
             ) is not None:  # bool(response) on status errors returns False
@@ -277,6 +290,8 @@ async def handle_traptagger_attachment(
         "traptagger_dispatcher.handle_traptagger_attachment", kind=SpanKind.CONSUMER
     ) as current_span:
         current_span.set_attribute("payload", repr(event.payload))
+        gundi_id = attributes.get("gundi_id")
+        data_provider_id = attributes.get("data_provider_id")
         destination_id = attributes.get("destination_id")
         current_span.set_attribute("destination_id", destination_id)
         destination_integration = await get_destination_integration(
@@ -285,9 +300,60 @@ async def handle_traptagger_attachment(
         # Look for the related event which contains the camera ID
         related_to = attributes.get("related_to")
         current_span.set_attribute("destination_id", destination_id)
-        related_event = await get_related_event(
-            event_id=related_to, destination_id=destination_id
-        )
+        try:
+            related_event = await get_related_event(
+                event_id=related_to, destination_id=destination_id
+            )
+        except ReferenceDataError as e:
+            event_time = event.timestamp
+            if event_time.tzinfo is None:
+                event_time = event_time.replace(tzinfo=timezone.utc)
+            event_age_seconds = (
+                datetime.now(timezone.utc) - event_time
+            ).total_seconds()
+            if event_age_seconds < settings.IMAGE_METADATA_CACHE_TTL:
+                # Normal race: the attachment arrived before its metadata.
+                # The metadata may still arrive, so warn and retry.
+                await publish_event(
+                    event=system_events.DispatcherCustomLog(
+                        payload=gundi_schemas_v2.CustomDispatcherLog(
+                            gundi_id=gundi_id,
+                            related_to=related_to,
+                            data_provider_id=data_provider_id,
+                            destination_id=destination_id,
+                            title=f"Attachment {gundi_id} received before the metadata of related observation {related_to}. It will be retried.",
+                            level=gundi_schemas_v2.LogLevel.WARNING,
+                        )
+                    ),
+                    topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+                )
+                raise e
+            # The metadata cache TTL has expired, so this attachment can never be delivered
+            error_msg = (
+                f"Error dispatching attachment {gundi_id} to destination {destination_id}: "
+                f"metadata of related observation {related_to} was not found and the message is older "
+                f"than IMAGE_METADATA_CACHE_TTL ({settings.IMAGE_METADATA_CACHE_TTL} seconds). It will not be retried."
+            )
+            logger.error(error_msg)
+            current_span.set_attribute("error", error_msg)
+            await publish_event(
+                event=system_events.ObservationDeliveryFailed(
+                    payload=system_events.DeliveryErrorDetails(
+                        error=error_msg,
+                        error_traceback=traceback.format_exc(),
+                        observation=gundi_schemas_v2.DispatchedObservation(
+                            gundi_id=gundi_id,
+                            related_to=related_to,
+                            external_id=None,
+                            data_provider_id=data_provider_id,
+                            destination_id=destination_id,
+                            delivered_at=datetime.now(timezone.utc),  # UTC
+                        ),
+                    )
+                ),
+                topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+            )
+            raise NonRetryableDispatchError(error_msg) from e
         # Send image plus metadata to WPS Watch
         return await dispatch_image(
             integration=destination_integration,

--- a/app/services/process_messages.py
+++ b/app/services/process_messages.py
@@ -6,6 +6,7 @@ from gcloud.aio import pubsub
 from gundi_core.schemas.v2 import StreamPrefixEnum
 from opentelemetry.trace import SpanKind
 from app.core import settings
+from app.core.errors import NonRetryableDispatchError
 from app.core.utils import (
     extract_fields_from_message,
 )
@@ -130,7 +131,15 @@ async def process_transformer_event_v2(raw_event, attributes):
             )
             return {}
         parsed_event = schema.parse_obj(raw_event)
-        return await handler(event=parsed_event, attributes=attributes)
+        try:
+            return await handler(event=parsed_event, attributes=attributes)
+        except NonRetryableDispatchError as e:
+            logger.warning(
+                f"Permanent error processing event of type '{event_type}': {e}. Sending message to the dead letter topic."
+            )
+            current_span.set_attribute("is_sent_to_dead_letter_queue", True)
+            await send_observation_to_dead_letter_topic(raw_event, attributes)
+            return {"status": "dead-lettered"}
 
 
 async def process_request(request):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import json
 import httpx
@@ -414,3 +415,72 @@ def mock_traptagger_error_response(request):
                 "POST", "https://test.traptagger.com/api/v1/addImage"
             ),
         )
+
+
+def _attachment_pubsub_request(mocker, event_timestamp: datetime.datetime):
+    # Same message as attachment_v2_as_pubsub_request but with a configurable event timestamp,
+    # used to test the buffer-miss paths (message age vs IMAGE_METADATA_CACHE_TTL)
+    mock_request = mocker.MagicMock()
+    mock_request.headers = [
+        ("Host", "traptagger-dis-ddd0946d-15b0-4308-b93d-e0470-jba4og2dyq-uc.a.run.app")
+    ]
+    publish_time = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
+    event_data = {
+        "event_id": "c2bcc65e-81c9-4e22-9aad-47b0f2408f01",
+        "timestamp": str(event_timestamp),
+        "schema_version": "v1",
+        "payload": {
+            "file_path": "attachments/259a2767-d7a0-462e-a881-57bf746f53d1_elephant_single_20250305.jpg"
+        },
+        "event_type": "AttachmentTransformedTrapTagger",
+    }
+    encoded_data = base64.b64encode(json.dumps(event_data).encode("utf-8")).decode(
+        "utf-8"
+    )
+    json_data = {
+        "message": {
+            "data": encoded_data,
+            "attributes": {
+                "annotations": "null",
+                "data_provider_id": "b976ac0e-135a-4212-88b7-7bfc58e897a2",
+                "destination_id": "a16f0110-bf40-4518-9c68-9018c6ec8f6d",
+                "external_source_id": "None",
+                "gundi_id": "259a2767-d7a0-462e-a881-57bf746f53d1",
+                "gundi_version": "v2",
+                "provider_key": "gundi_wps_watch_r_b976ac0e-135a-4212-88b7-7bfc58e897a2",
+                "related_to": "56a5afe0-7829-47d1-a496-80dcbf816593",
+                "source_id": "None",
+                "stream_type": "att",
+                "tracing_context": "{}",
+            },
+            "messageId": "14148756572947596",
+            "message_id": "14148756572947596",
+            "orderingKey": "",
+            "publishTime": f"{publish_time}",
+            "publish_time": f"{publish_time}",
+        },
+        "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB",  # pragma: allowlist secret
+    }
+    mock_request.data = json.dumps(json_data)
+    mock_request.get_json.return_value = json_data
+    mock_request.json.return_value = async_return(json_data)
+    return mock_request
+
+
+@pytest.fixture
+def fresh_attachment_v2_as_pubsub_request(mocker):
+    # An attachment message younger than IMAGE_METADATA_CACHE_TTL
+    return _attachment_pubsub_request(
+        mocker, event_timestamp=datetime.datetime.now(datetime.timezone.utc)
+    )
+
+
+@pytest.fixture
+def expired_attachment_v2_as_pubsub_request(mocker):
+    # An attachment message older than IMAGE_METADATA_CACHE_TTL
+    event_timestamp = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=settings.IMAGE_METADATA_CACHE_TTL + 60
+    )
+    return _attachment_pubsub_request(mocker, event_timestamp=event_timestamp)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -484,3 +484,27 @@ def expired_attachment_v2_as_pubsub_request(mocker):
         seconds=settings.IMAGE_METADATA_CACHE_TTL + 60
     )
     return _attachment_pubsub_request(mocker, event_timestamp=event_timestamp)
+
+
+@pytest.fixture
+def cached_event_without_location():
+    # Camera with no location configured at the source (real case from GUNDI-5535)
+    return '{"camera": "Benguerra South 01", "latitude": "0.0", "longitude": "0.0", "timestamp": "2026-07-31 15:19:46"}'
+
+
+@pytest.fixture
+def mock_redis_with_cached_event_without_location(
+    mocker, cached_event_without_location
+):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.return_value = async_return(cached_event_without_location)
+    mock_cache.setex.return_value = async_return(None)
+    mock_cache.incr.return_value = mock_cache
+    mock_cache.decr.return_value = async_return(None)
+    mock_cache.expire.return_value = mock_cache
+    mock_cache.execute.return_value = async_return((1, True))
+    mock_cache.__aenter__.return_value = mock_cache
+    mock_cache.__aexit__.return_value = None
+    mock_cache.close.return_value = async_return(None)
+    mock_cache.pipeline.return_value = mock_cache
+    return mock_cache

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -16,10 +16,9 @@ def async_return(result):
     return f
 
 
-@pytest.fixture
-def mock_redis(mocker):
+def _mock_redis_cache(mocker, cached_value=None):
     mock_cache = mocker.MagicMock()
-    mock_cache.get.return_value = async_return(None)
+    mock_cache.get.return_value = async_return(cached_value)
     mock_cache.setex.return_value = async_return(None)
     mock_cache.incr.return_value = mock_cache
     mock_cache.decr.return_value = async_return(None)
@@ -30,6 +29,11 @@ def mock_redis(mocker):
     mock_cache.close.return_value = async_return(None)
     mock_cache.pipeline.return_value = mock_cache
     return mock_cache
+
+
+@pytest.fixture
+def mock_redis(mocker):
+    return _mock_redis_cache(mocker)
 
 
 @pytest.fixture
@@ -39,18 +43,7 @@ def cached_event():
 
 @pytest.fixture
 def mock_redis_with_cached_event(mocker, cached_event):
-    mock_cache = mocker.MagicMock()
-    mock_cache.get.return_value = async_return(cached_event)
-    mock_cache.setex.return_value = async_return(None)
-    mock_cache.incr.return_value = mock_cache
-    mock_cache.decr.return_value = async_return(None)
-    mock_cache.expire.return_value = mock_cache
-    mock_cache.execute.return_value = async_return((1, True))
-    mock_cache.__aenter__.return_value = mock_cache
-    mock_cache.__aexit__.return_value = None
-    mock_cache.close.return_value = async_return(None)
-    mock_cache.pipeline.return_value = mock_cache
-    return mock_cache
+    return _mock_redis_cache(mocker, cached_event)
 
 
 @pytest.fixture
@@ -260,41 +253,12 @@ def event_v2_as_pubsub_request(mocker):
 
 @pytest.fixture
 def attachment_v2_as_pubsub_request(mocker):
-    mock_request = mocker.MagicMock()
-    mock_request.headers = [
-        ("Host", "traptagger-dis-ddd0946d-15b0-4308-b93d-e0470-jba4og2dyq-uc.a.run.app")
-    ]
-    publish_time = datetime.datetime.now(datetime.timezone.utc).strftime(
-        "%Y-%m-%dT%H:%M:%S.%fZ"
+    return _attachment_pubsub_request(
+        mocker,
+        event_timestamp=datetime.datetime.fromisoformat(
+            "2025-03-05 12:20:22.700737+00:00"
+        ),
     )
-    json_data = {
-        "message": {
-            "data": "eyJldmVudF9pZCI6ICJjMmJjYzY1ZS04MWM5LTRlMjItOWFhZC00N2IwZjI0MDhmMDEiLCAidGltZXN0YW1wIjogIjIwMjUtMDMtMDUgMTI6MjA6MjIuNzAwNzM3KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7ImZpbGVfcGF0aCI6ICJhdHRhY2htZW50cy8yNTlhMjc2Ny1kN2EwLTQ2MmUtYTg4MS01N2JmNzQ2ZjUzZDFfZWxlcGhhbnRfc2luZ2xlXzIwMjUwMzA1LmpwZyJ9LCAiZXZlbnRfdHlwZSI6ICJBdHRhY2htZW50VHJhbnNmb3JtZWRUcmFwVGFnZ2VyIn0=",  # pragma: allowlist secret
-            "attributes": {
-                "annotations": "null",
-                "data_provider_id": "b976ac0e-135a-4212-88b7-7bfc58e897a2",
-                "destination_id": "a16f0110-bf40-4518-9c68-9018c6ec8f6d",
-                "external_source_id": "None",
-                "gundi_id": "259a2767-d7a0-462e-a881-57bf746f53d1",
-                "gundi_version": "v2",
-                "provider_key": "gundi_wps_watch_r_b976ac0e-135a-4212-88b7-7bfc58e897a2",
-                "related_to": "56a5afe0-7829-47d1-a496-80dcbf816593",
-                "source_id": "None",
-                "stream_type": "att",
-                "tracing_context": "{}",
-            },
-            "messageId": "14148756572947596",
-            "message_id": "14148756572947596",
-            "orderingKey": "",
-            "publishTime": f"{publish_time}",
-            "publish_time": f"{publish_time}",
-        },
-        "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB",  # pragma: allowlist secret
-    }
-    mock_request.data = json.dumps(json_data)
-    mock_request.get_json.return_value = json_data
-    mock_request.json.return_value = async_return(json_data)
-    return mock_request
 
 
 @pytest.fixture
@@ -496,15 +460,4 @@ def cached_event_without_location():
 def mock_redis_with_cached_event_without_location(
     mocker, cached_event_without_location
 ):
-    mock_cache = mocker.MagicMock()
-    mock_cache.get.return_value = async_return(cached_event_without_location)
-    mock_cache.setex.return_value = async_return(None)
-    mock_cache.incr.return_value = mock_cache
-    mock_cache.decr.return_value = async_return(None)
-    mock_cache.expire.return_value = mock_cache
-    mock_cache.execute.return_value = async_return((1, True))
-    mock_cache.__aenter__.return_value = mock_cache
-    mock_cache.__aexit__.return_value = None
-    mock_cache.close.return_value = async_return(None)
-    mock_cache.pipeline.return_value = mock_cache
-    return mock_cache
+    return _mock_redis_cache(mocker, cached_event_without_location)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -355,6 +355,14 @@ def mock_traptagger_error_response(request):
                 "POST", "https://test.traptagger.com/api/v1/addImage"
             ),
         )
+    elif request.param == "forbidden":
+        return httpx.Response(
+            status_code=403,
+            content=b'{"message": "Forbidden."}',
+            request=httpx.Request(
+                "POST", "https://test.traptagger.com/api/v1/addImage"
+            ),
+        )
     elif request.param == "bad_request":
         return httpx.Response(
             status_code=400,

--- a/app/tests/test_dispatchers.py
+++ b/app/tests/test_dispatchers.py
@@ -68,7 +68,10 @@ async def test_dispatch_image_successfully(
 @pytest.mark.parametrize(
     "mock_traptagger_error_response,expected_exception",
     [
-        ("bad_credentials", NonRetryableDispatchError),
+        # Auth errors are retried: a rotated/expired API key is usually fixed,
+        # and dead-lettering on first attempt would force a bulk DLQ replay
+        ("bad_credentials", httpx.HTTPStatusError),
+        ("forbidden", httpx.HTTPStatusError),
         ("bad_request", NonRetryableDispatchError),
         ("service_unavailable", httpx.HTTPStatusError),
         ("internal_error", httpx.HTTPStatusError),

--- a/app/tests/test_dispatchers.py
+++ b/app/tests/test_dispatchers.py
@@ -3,6 +3,7 @@ import httpx
 import pytest
 from gundi_core.events import dispatchers as dispatcher_events
 from app.core import settings
+from app.core.errors import NonRetryableDispatchError
 
 
 @pytest.mark.parametrize(
@@ -65,18 +66,19 @@ async def test_dispatch_image_successfully(
 
 
 @pytest.mark.parametrize(
-    "mock_traptagger_error_response",
+    "mock_traptagger_error_response,expected_exception",
     [
-        "bad_credentials",
-        "bad_request",
-        "service_unavailable",
-        "internal_error",
+        ("bad_credentials", NonRetryableDispatchError),
+        ("bad_request", NonRetryableDispatchError),
+        ("service_unavailable", httpx.HTTPStatusError),
+        ("internal_error", httpx.HTTPStatusError),
     ],
     indirect=["mock_traptagger_error_response"],
 )
 @pytest.mark.asyncio
 async def test_dispatch_image_on_errors(
     mock_traptagger_error_response,
+    expected_exception,
     mocker,
     mock_redis,
     mock_cloud_storage_client,
@@ -104,7 +106,7 @@ async def test_dispatch_image_on_errors(
             status_code=mock_traptagger_error_response.status_code,
             content=mock_traptagger_error_response.text,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(expected_exception):
             await dispatch_image(
                 integration=destination_integration_v2_traptagger,
                 image=attachment_v2_transformed_traptagger.payload,
@@ -127,3 +129,49 @@ async def test_dispatch_image_on_errors(
     assert payload.error
     assert payload.server_response_status == mock_traptagger_error_response.status_code
     assert payload.server_response_body == mock_traptagger_error_response.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_image_on_error_without_response(
+    mocker,
+    mock_redis,
+    mock_cloud_storage_client,
+    mock_publish_event,
+    event_v2_transformed_traptagger,
+    attachment_v2_transformed_traptagger,
+    attachment_v2_transformed_traptagger_attributes,
+    destination_integration_v2_traptagger,
+):
+    # Errors without a response attached (e.g. connection errors) must also be reported
+    from app.services.event_handlers import dispatch_image
+
+    # Mock external dependencies
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.services.event_handlers.publish_event", mock_publish_event)
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+
+    async with respx.mock(
+        base_url=destination_integration_v2_traptagger.base_url,
+        assert_all_called=True,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        respx_mock.post("/api/v1/addImage").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(httpx.ConnectError):
+            await dispatch_image(
+                integration=destination_integration_v2_traptagger,
+                image=attachment_v2_transformed_traptagger.payload,
+                related_event=event_v2_transformed_traptagger.payload,
+                attributes=attachment_v2_transformed_traptagger_attributes,
+            )
+
+    # The failure must be published, with no server response details
+    assert mock_publish_event.call_count == 1
+    published_event = mock_publish_event.call_args_list[0].kwargs["event"]
+    assert isinstance(published_event, dispatcher_events.ObservationDeliveryFailed)
+    payload = published_event.payload
+    assert isinstance(payload.error, str)
+    assert payload.server_response_status is None
+    assert payload.server_response_body is None

--- a/app/tests/test_process_requests.py
+++ b/app/tests/test_process_requests.py
@@ -188,7 +188,7 @@ async def test_process_attachment_v2_with_permanent_client_error_is_dead_lettere
         # TrapTagger rejects the image with a permanent client error
         route = respx_mock.post("api/v1/addImage").respond(
             httpx.codes.BAD_REQUEST,
-            json={"message": "Missing site information."},
+            json={"message": "No image provided."},
         )
         from app.main import app
 
@@ -360,7 +360,7 @@ async def test_process_attachment_v2_without_location_warns_and_dead_letters(
     mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
     async with respx.mock(
         base_url=destination_integration_v2_traptagger.base_url,
-        assert_all_called=False,
+        assert_all_called=True,
         assert_all_mocked=True,
     ) as respx_mock:
         route = respx_mock.post("api/v1/addImage").respond(
@@ -377,8 +377,8 @@ async def test_process_attachment_v2_without_location_warns_and_dead_letters(
             )
             # The message must be acked (no retries)
             assert response.status_code == 200
-            # TrapTagger must NOT be called: the request is known to fail
-            assert not route.called
+            # The image is still posted, in case TrapTagger accepts it in the future
+            assert route.call_count == 1
 
     # A WARNING custom log must be published instead of a delivery error
     event_types = _published_event_types(mock_pubsub_client)
@@ -388,7 +388,7 @@ async def test_process_attachment_v2_without_location_warns_and_dead_letters(
         message = json.loads(call.args[0])
         if message.get("event_type") == "DispatcherCustomLog":
             assert message["payload"]["level"] == 30  # WARNING
-            assert "site identifier or location" in message["payload"]["title"]
+            assert "site identifier or a valid location" in message["payload"]["title"]
     # The message must be sent to the attachments dead letter topic
     topics = _topics_published_to(mock_pubsub_client)
     assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics

--- a/app/tests/test_process_requests.py
+++ b/app/tests/test_process_requests.py
@@ -142,3 +142,195 @@ async def test_process_attachment_v2_successfully(
             )
             assert response.status_code == 200
             assert route.called
+
+
+def _published_event_types(mock_pubsub_client):
+    # Extract the event_type of every message built for publishing
+    event_types = []
+    for call in mock_pubsub_client.PubsubMessage.call_args_list:
+        try:
+            message = json.loads(call.args[0])
+        except (ValueError, TypeError, IndexError):
+            continue
+        event_types.append(message.get("event_type"))
+    return event_types
+
+
+def _topics_published_to(mock_pubsub_client):
+    publisher = mock_pubsub_client.PublisherClient.return_value
+    return [call.args[1] for call in publisher.topic_path.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_process_attachment_v2_with_permanent_client_error_is_dead_lettered(
+    mocker,
+    mock_redis,
+    mock_redis_with_cached_event,
+    mock_gundi_client_v2_class,
+    mock_cloud_storage_client,
+    mock_pubsub_client,
+    attachment_v2_as_pubsub_request,
+    destination_integration_v2_traptagger,
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.core.system_events.pubsub", mock_pubsub_client)
+    mocker.patch("app.services.event_handlers._cache_db", mock_redis_with_cached_event)
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    async with respx.mock(
+        base_url=destination_integration_v2_traptagger.base_url,
+        assert_all_called=True,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        # TrapTagger rejects the image with a permanent client error
+        route = respx_mock.post("api/v1/addImage").respond(
+            httpx.codes.BAD_REQUEST,
+            json={"message": "Missing site information."},
+        )
+        from app.main import app
+
+        with TestClient(app) as api_client:
+            response = api_client.post(
+                "/",
+                headers=attachment_v2_as_pubsub_request.headers,
+                json=attachment_v2_as_pubsub_request.get_json(),
+            )
+            # The message must be acked (no retries)
+            assert response.status_code == 200
+            assert route.call_count == 1
+
+        # Exactly one delivery failure event must be published for the portal
+        event_types = _published_event_types(mock_pubsub_client)
+        assert event_types.count("ObservationDeliveryFailed") == 1
+        # The message must be sent to the attachments dead letter topic
+        topics = _topics_published_to(mock_pubsub_client)
+        assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics
+
+
+@pytest.mark.asyncio
+async def test_process_attachment_v2_with_server_error_is_retried(
+    mocker,
+    mock_redis,
+    mock_redis_with_cached_event,
+    mock_gundi_client_v2_class,
+    mock_cloud_storage_client,
+    mock_pubsub_client,
+    attachment_v2_as_pubsub_request,
+    destination_integration_v2_traptagger,
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.core.system_events.pubsub", mock_pubsub_client)
+    mocker.patch("app.services.event_handlers._cache_db", mock_redis_with_cached_event)
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    async with respx.mock(
+        base_url=destination_integration_v2_traptagger.base_url,
+        assert_all_called=True,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        # TrapTagger has a transient problem
+        respx_mock.post("api/v1/addImage").respond(
+            httpx.codes.SERVICE_UNAVAILABLE,
+            json={"message": "Service unavailable."},
+        )
+        from app.main import app
+
+        with TestClient(app) as api_client:
+            # The error must be raised so GCP retries the message
+            with pytest.raises(httpx.HTTPStatusError):
+                api_client.post(
+                    "/",
+                    headers=attachment_v2_as_pubsub_request.headers,
+                    json=attachment_v2_as_pubsub_request.get_json(),
+                )
+
+        # A delivery failure event must be published for the portal
+        event_types = _published_event_types(mock_pubsub_client)
+        assert event_types.count("ObservationDeliveryFailed") == 1
+        # The message must NOT be dead-lettered
+        topics = _topics_published_to(mock_pubsub_client)
+        assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC not in topics
+
+
+@pytest.mark.asyncio
+async def test_process_attachment_v2_young_buffer_miss_is_retried(
+    mocker,
+    mock_redis,
+    mock_gundi_client_v2_class,
+    mock_cloud_storage_client,
+    mock_pubsub_client,
+    fresh_attachment_v2_as_pubsub_request,
+    destination_integration_v2_traptagger,
+):
+    from app.core.errors import ReferenceDataError
+
+    # Mock external dependencies. The metadata cache is empty (mock_redis returns None)
+    mocker.patch("app.core.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.core.system_events.pubsub", mock_pubsub_client)
+    mocker.patch("app.services.event_handlers._cache_db", mock_redis)
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    from app.main import app
+
+    with TestClient(app) as api_client:
+        # The error must be raised so GCP retries the message
+        with pytest.raises(ReferenceDataError) as exc_info:
+            api_client.post(
+                "/",
+                headers=fresh_attachment_v2_as_pubsub_request.headers,
+                json=fresh_attachment_v2_as_pubsub_request.get_json(),
+            )
+
+    # The error message must be a plain string (not a tuple)
+    assert isinstance(exc_info.value.args[0], str)
+    # A custom log must be published so the race is visible in the portal
+    event_types = _published_event_types(mock_pubsub_client)
+    assert event_types.count("DispatcherCustomLog") == 1
+    # The message must NOT be dead-lettered
+    topics = _topics_published_to(mock_pubsub_client)
+    assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC not in topics
+
+
+@pytest.mark.asyncio
+async def test_process_attachment_v2_expired_buffer_miss_is_dead_lettered(
+    mocker,
+    mock_redis,
+    mock_gundi_client_v2_class,
+    mock_cloud_storage_client,
+    mock_pubsub_client,
+    expired_attachment_v2_as_pubsub_request,
+    destination_integration_v2_traptagger,
+):
+    # Mock external dependencies. The metadata cache is empty (mock_redis returns None)
+    mocker.patch("app.core.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.core.system_events.pubsub", mock_pubsub_client)
+    mocker.patch("app.services.event_handlers._cache_db", mock_redis)
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    from app.main import app
+
+    with TestClient(app) as api_client:
+        response = api_client.post(
+            "/",
+            headers=expired_attachment_v2_as_pubsub_request.headers,
+            json=expired_attachment_v2_as_pubsub_request.get_json(),
+        )
+        # The message must be acked (no retries)
+        assert response.status_code == 200
+
+    # Exactly one delivery failure event must be published for the portal
+    event_types = _published_event_types(mock_pubsub_client)
+    assert event_types.count("ObservationDeliveryFailed") == 1
+    # The message must be sent to the attachments dead letter topic
+    topics = _topics_published_to(mock_pubsub_client)
+    assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics

--- a/app/tests/test_process_requests.py
+++ b/app/tests/test_process_requests.py
@@ -380,15 +380,20 @@ async def test_process_attachment_v2_without_location_warns_and_dead_letters(
             # The image is still posted, in case TrapTagger accepts it in the future
             assert route.call_count == 1
 
-    # A WARNING custom log must be published instead of a delivery error
+    # A WARNING custom log must be published with the actionable message,
+    # and a delivery failure must also be recorded so the portal doesn't
+    # show the observation as perpetually in-flight
     event_types = _published_event_types(mock_pubsub_client)
     assert event_types.count("DispatcherCustomLog") == 1
-    assert event_types.count("ObservationDeliveryFailed") == 0
+    assert event_types.count("ObservationDeliveryFailed") == 1
     for call in mock_pubsub_client.PubsubMessage.call_args_list:
         message = json.loads(call.args[0])
         if message.get("event_type") == "DispatcherCustomLog":
             assert message["payload"]["level"] == 30  # WARNING
             assert "site identifier or a valid location" in message["payload"]["title"]
+        elif message.get("event_type") == "ObservationDeliveryFailed":
+            assert message["payload"]["server_response_status"] == 400
+            assert "site identifier or a valid location" in message["payload"]["error"]
     # The message must be sent to the attachments dead letter topic
     topics = _topics_published_to(mock_pubsub_client)
     assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics

--- a/app/tests/test_process_requests.py
+++ b/app/tests/test_process_requests.py
@@ -334,3 +334,61 @@ async def test_process_attachment_v2_expired_buffer_miss_is_dead_lettered(
     # The message must be sent to the attachments dead letter topic
     topics = _topics_published_to(mock_pubsub_client)
     assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics
+
+
+@pytest.mark.asyncio
+async def test_process_attachment_v2_without_location_warns_and_dead_letters(
+    mocker,
+    mock_redis,
+    mock_redis_with_cached_event_without_location,
+    mock_gundi_client_v2_class,
+    mock_cloud_storage_client,
+    mock_pubsub_client,
+    attachment_v2_as_pubsub_request,
+    destination_integration_v2_traptagger,
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.core.utils.redis_client", mock_redis)
+    mocker.patch("app.core.system_events.pubsub", mock_pubsub_client)
+    mocker.patch(
+        "app.services.event_handlers._cache_db",
+        mock_redis_with_cached_event_without_location,
+    )
+    mocker.patch("app.services.dispatchers.redis_client", mock_redis)
+    mocker.patch("app.services.dispatchers.gcp_storage", mock_cloud_storage_client)
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    async with respx.mock(
+        base_url=destination_integration_v2_traptagger.base_url,
+        assert_all_called=False,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        route = respx_mock.post("api/v1/addImage").respond(
+            httpx.codes.BAD_REQUEST,
+            json={"message": "Missing site information."},
+        )
+        from app.main import app
+
+        with TestClient(app) as api_client:
+            response = api_client.post(
+                "/",
+                headers=attachment_v2_as_pubsub_request.headers,
+                json=attachment_v2_as_pubsub_request.get_json(),
+            )
+            # The message must be acked (no retries)
+            assert response.status_code == 200
+            # TrapTagger must NOT be called: the request is known to fail
+            assert not route.called
+
+    # A WARNING custom log must be published instead of a delivery error
+    event_types = _published_event_types(mock_pubsub_client)
+    assert event_types.count("DispatcherCustomLog") == 1
+    assert event_types.count("ObservationDeliveryFailed") == 0
+    for call in mock_pubsub_client.PubsubMessage.call_args_list:
+        message = json.loads(call.args[0])
+        if message.get("event_type") == "DispatcherCustomLog":
+            assert message["payload"]["level"] == 30  # WARNING
+            assert "site identifier or location" in message["payload"]["title"]
+    # The message must be sent to the attachments dead letter topic
+    topics = _topics_published_to(mock_pubsub_client)
+    assert settings.ATTACHMENTS_DEAD_LETTER_TOPIC in topics


### PR DESCRIPTION
## Summary

[GUNDI-5535]: https://allenai.atlassian.net/browse/GUNDI-5535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# What's happening today

When we send a camera-trap image to TrapTagger and something goes wrong, the dispatcher treats every failure the same way: it logs an error in the portal and asks Google Pub/Sub to try again later. Pub/Sub retries roughly every 7 minutes, for up to 24 hours.

That's the right behavior when the problem is temporary — TrapTagger is briefly down, the network hiccups. But some failures are permanent. In the incident that triggered this ticket, TrapTagger rejected images with "400 Missing site information" — meaning the data itself is wrong, and no amount of retrying will ever make it succeed. The dispatcher retried anyway, so each bad image generated around 200 identical POSTs to TrapTagger and 200 duplicate error entries in the portal over 24 hours. That's why the connection's activity log looked flooded with errors: most of them were the same few images failing over and over.

# What the PR changes

1. It tells permanent failures apart from temporary ones. If TrapTagger answers with an error that means "this request will never work" (like 400 Bad Request), the dispatcher now records one error in the portal, moves the message to the dead-letter queue (a holding area for undeliverable messages, so nothing is lost and we can inspect or replay it later), and stops. Temporary errors (server down, timeout) still retry like before.
2. It fixes a silent failure mode. Images and their metadata (camera ID, location) travel as two separate messages, and the image sometimes arrives first. The dispatcher waits and retries, which normally resolves in seconds. But the metadata is only kept for 1 hour — if it never shows up, the image would retry pointlessly for 24 hours without any error appearing in the portal at all. Now: during the first hour you see a warning in the portal ("image arrived before its metadata, retrying"), and after the hour it's declared undeliverable — one error entry, one dead-letter message, done.
3. Two small cleanups. An error message was accidentally formatted as ('Error getting related observation …',) instead of plain text, which broke log searches. And a bug in the error-reporting code itself meant that failures without an HTTP response (network drops, storage problems) crashed the error handler — so those failures were never reported to the portal either.
4. It turns the "missing site information" rejection into an actionable warning. This was the exact error behind recent  incidents: cameras with no location configured (0,0 coordinates) are rejected by TrapTagger because it can't tell which site the image belongs to. Instead of a technical error ("HTTPStatusError: Client error '400 BAD REQUEST'"), the portal now shows a warning that says what's wrong and who can fix it: "TrapTagger rejected image …: camera 'Benguerra South 01' needs a site identifier or a valid location (current latitude/longitude: 0.0,0.0). Please set the camera location in the data provider." The image is still posted to TrapTagger first (in case they accept location-less cameras in the future) — the warning is based on TrapTagger's actual response, not a guess. Any other 400 we don't recognize still shows as an error, so new failure causes stay visible.

What you'll see after this ships
* A bad image produces one clear error in the portal instead of ~200 duplicates, so real problems stand out instead of drowning in repeats.
* TrapTagger's API stops getting hammered with requests that can't succeed.
* Situations that used to be invisible (orphaned images, network failures) now show up in the portal, so support can see why something didn't arrive instead of just noticing it's missing.
* Nothing is silently thrown away — every undeliverable message ends up in the dead-letter queue where it can be reviewed or replayed.


# Accepted for this version (out of scope, possible follow-ups)

- **All 4xx except 408/429 dead-letter immediately, including auth errors.** If TrapTagger rejects with a credentials-type 4xx, the message dead-letters on first attempt instead of retrying. Accepted: recovery is replaying from the DLQ. 
- **Young buffer misses publish one WARNING per retry** (~9 per hour for an attachment whose metadata never arrives, one for a benign out-of-order race). Accepted for now — still far better than the previous silent 24h retry loop. Possible later improvement: a Redis flag (`buffer_miss_warned.{gundi_id}.{destination_id}`, TTL = `IMAGE_METADATA_CACHE_TTL`) to warn only on the first attempt, optionally with a grace period (e.g. only warn after 10 minutes) so benign races produce no warning at all.
- **A transient failure that surfaces as a 4xx dead-letters.** The retryable/permanent split is by HTTP status only; if TrapTagger ever returns a 4xx during an outage, those messages go to the DLQ and would need replaying.

