### PR TITLE
Pin CI workflows to gundi-workflows@v8 to unblock Docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   main:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   pr:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   release:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@v8
     secrets: inherit
     with:
       app_name: traptagger


### PR DESCRIPTION
## Problem

The **Main Workflow** and **Release Workflow** have been failing since PR #7 merged. The failure is not in this repo's code — unit tests pass. Both runs die at `Set up Docker Buildx`:

```
ERROR: denied: Unauthenticated request. Unauthenticated requests do not have
permission "artifactregistry.repositories.downloadArtifacts" on resource
"projects/serca-artifact-registry/locations/europe-west3/repositories/virtual-docker"
```

## Root cause (upstream)

`PADAS/gundi-workflows/.github/workflows/build_docker.yml`, pulled via `@main`, points BuildKit at the `serca-artifact-registry` mirror unconditionally, but only authenticates to that registry host on the Direct WIF path:

```yaml
- name: Login to GAR registry host (Direct WIF)
  if: ${{ env.SERVICE_ACCOUNT == '' }}      # ← gated
  with:
    registry: europe-west3-docker.pkg.dev
...
- name: Set up Docker Buildx
  with:
    driver-opts: |
      image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
```

This repo's `dev`/`stage`/`prod` environments set `vars.SERVICE_ACCOUNT`, so we take the SA-based branch and the login never happens. Confirmed from the failed job's step list:

```
success   GCP Auth (SA-based)
skipped   Login to GAR registry host (Direct WIF)
failure   Set up Docker Buildx
```

Introduced upstream on 2026-05-13 by gundi-workflows `adb64b74` (PR #10, DASOPS-2057), which switched BuildKit to the mirror to dodge DockerHub rate limits. Our last successful Main Workflow was 2025-08-21, so PR #7 was simply the first main-branch build since then. **Every Gundi dispatcher repo pinned to `@main` is broken the same way.** PR builds kept passing only because `pipeline-dispatcher-docker-pr.yml` doesn't build an image.

## Fix

Pin all three workflows to `@v8`, the last gundi-workflows tag before that change.

This is surgical: `_dispatcher_common.yml`, all three `pipeline-dispatcher-docker-*.yml`, and `update_json_secret_key.yml` are **byte-identical between `v8` and `main`** (verified). `build_docker.yml` is the only difference, so the pin reverts exactly the broken file and gives up nothing else. The inputs this repo passes are compatible with `v8`.

## Validation

`pr.yml` on this branch doesn't build an image, so this PR's own check won't exercise the fix — the Main Workflow run on merge is the real verification.

## Follow-up

This is a stopgap. The durable fix belongs in `gundi-workflows`: either scope `driver-opts` to the Direct WIF path, or grant the `cdip-78ca` service account `artifactregistry.reader` on `serca-artifact-registry`. Worth reopening DASOPS-2057 — and note the release branch `release-20260805` needs the same pin (or an upstream fix) before its build will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)