### PR TITLE
Pin CI workflows to gundi-workflows@v8 to unblock Docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   main:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   pr:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   release:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@v8
     secrets: inherit
     with:
       app_name: traptagger


### PR DESCRIPTION
The Main and Release workflows have been failing at "Set up Docker Buildx" since the merge of PR #7. The cause is upstream: gundi-workflows build_docker.yml (pulled via @main) configures BuildKit to pull its image from the europe-west3 serca-artifact-registry mirror, but only logs in to that registry host on the Direct WIF auth path (if: SERVICE_ACCOUNT == ''). This repo's dev/stage/prod environments set vars.SERVICE_ACCOUNT, so we take the SA-based path, the login step is skipped, and the BuildKit pull fails with "denied: Unauthenticated request".

v8 is the last tag before that change (gundi-workflows adb64b74, DASOPS-2057). Every other file these pipelines pull in -- _dispatcher_common.yml, all three pipeline-dispatcher-docker-*.yml, and update_json_secret_key.yml -- is byte-identical between v8 and main, so pinning reverts only the broken build_docker.yml and loses nothing else.

Unpin once gundi-workflows either scopes the mirror to the Direct WIF path or grants the cdip-78ca service account read access to serca-artifact-registry.