### PR TITLE
Release 20260805

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   main:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-main.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   pr:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-pr.yml@v8
     secrets: inherit
     with:
       app_name: traptagger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   release:
-    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@main
+    # Pinned to v8: @main pulls BuildKit from the serca-artifact-registry mirror
+    # without authenticating to it on the SA-based auth path (DASOPS-2057).
+    uses: PADAS/gundi-workflows/.github/workflows/pipeline-dispatcher-docker-release.yml@v8
     secrets: inherit
     with:
       app_name: traptagger


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configurations to pin the workflow dispatcher actions to version `v8` instead of using the `main` branch. This change addresses an authentication issue with BuildKit when pulling from the artifact registry, as described in DASOPS-2057.

**Workflow configuration updates:**

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L10-R12): Updated the `pipeline-dispatcher-docker-main.yml` action reference from `@main` to `@v8` and added a comment explaining the reason for pinning.
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L9-R11): Updated the `pipeline-dispatcher-docker-pr.yml` action reference from `@main` to `@v8` and added a comment explaining the reason for pinning.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L10-R12): Updated the `pipeline-dispatcher-docker-release.yml` action reference from `@main` to `@v8` and added a comment explaining the reason for pinning.